### PR TITLE
Feat: Add Prettier Configuration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,40 @@
+# dependencies
+node_modules
+.pnp
+.pnp.js
+
+# testing
+coverage
+
+# next.js
+.next/
+out/
+build
+dist
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+# package files
+package-lock.json
+yarn.lock 

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,25 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "printWidth": 100,
+  "trailingComma": "es5",
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "bracketSpacing": true,
+  "jsxSingleQuote": false,
+  "quoteProps": "as-needed",
+  "plugins": ["prettier-plugin-tailwindcss", "@trivago/prettier-plugin-sort-imports"],
+  "importOrder": [
+    "^react",
+    "^next",
+    "<THIRD_PARTY_MODULES>",
+    "^@/components/(.*)$",
+    "^@/lib/(.*)$",
+    "^@/utils/(.*)$",
+    "^@/styles/(.*)$",
+    "^[./]"
+  ],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "prettier.requireConfig": true
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ## Getting Started
 
-
 First, install the dependencies:
 
 ```bash
@@ -23,8 +22,6 @@ npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-
 
 ## Deploy on Vercel
 

--- a/app/ReactQueryProvider.tsx
+++ b/app/ReactQueryProvider.tsx
@@ -1,22 +1,21 @@
-"use client";
+'use client';
 
-import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useState } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 declare global {
-    interface BigInt {
-        toJSON(): string;
-    }
+  interface BigInt {
+    toJSON(): string;
+  }
 }
 
 const ReactQueryProvider = ({ children }: { children: React.ReactNode }) => {
-    const [queryClient] = useState(() => new QueryClient());
-    BigInt.prototype['toJSON'] = function () {
-        return this.toString()
-    }
-    return (
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
+  const [queryClient] = useState(() => new QueryClient());
+  BigInt.prototype['toJSON'] = function () {
+    return this.toString();
+  };
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 };
 
 export default ReactQueryProvider;

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,7 +1,8 @@
-"use client";
+'use client';
 
-import { ReactNode } from "react";
-import Providers from "./providers";
+import { ReactNode } from 'react';
+
+import Providers from './providers';
 
 export function ContextProvider({ children }: { children: ReactNode }) {
   return <Providers>{children}</Providers>;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,15 +1,17 @@
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
 
-import type { Metadata } from "next";
-import { Inter } from "next/font/google";
-import "@styles/globals.css";
+import '@styles/globals.css';
+
 import { ContextProvider } from '.';
 import ReactQueryProvider from './ReactQueryProvider';
-const inter = Inter({ subsets: ["latin"] });
+
+const inter = Inter({ subsets: ['latin'] });
 
 // Websit Config
 export const metadata: Metadata = {
-  title: "OnRamp",
-  description: "Made with love by Team FIL-B",
+  title: 'OnRamp',
+  description: 'Made with love by Team FIL-B',
 };
 
 export default function RootLayout({
@@ -21,9 +23,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <ReactQueryProvider>
-          <ContextProvider>
-            {children}
-          </ContextProvider>
+          <ContextProvider>{children}</ContextProvider>
         </ReactQueryProvider>
       </body>
     </html>

--- a/app/onRamp/page.tsx
+++ b/app/onRamp/page.tsx
@@ -1,19 +1,21 @@
-"use client"
+'use client';
 
-import Header from "@components/header";
-import React, { useState, useRef, ChangeEvent, DragEvent } from 'react';
-import { Upload, File, Image, FileText, Check, X, UploadCloud } from 'lucide-react';
-import { uploadToIPFS } from "./pinata";
-import { generateCID, generatePiece } from "@/utils/dataPrep";
-import { ethers } from "ethers";
-import { useWaitForTransactionReceipt, useWriteContract } from "wagmi";
-import { ONRAMP_CONTRACT_ADDRESS, ONRAMP_CONTRACT_ABI } from "@components/contractDetails"
-import { FiUpload, FiFile, FiUsers, FiHardDrive, FiDatabase } from 'react-icons/fi';
+import React, { ChangeEvent, DragEvent, useRef, useState } from 'react';
+import { FiDatabase, FiFile, FiHardDrive, FiUpload, FiUsers } from 'react-icons/fi';
 
-const WETH_ADDRESS = "0xb44cc5FB8CfEdE63ce1758CE0CDe0958A7702a16";
+import { ONRAMP_CONTRACT_ABI, ONRAMP_CONTRACT_ADDRESS } from '@components/contractDetails';
+import Header from '@components/header';
+import { ethers } from 'ethers';
+import { Check, File, FileText, Image, Upload, UploadCloud, X } from 'lucide-react';
+import { useWaitForTransactionReceipt, useWriteContract } from 'wagmi';
+
+import { generateCID, generatePiece } from '@/utils/dataPrep';
+
+import { uploadToIPFS } from './pinata';
+
+const WETH_ADDRESS = '0xb44cc5FB8CfEdE63ce1758CE0CDe0958A7702a16';
 
 export default function OnRamp() {
-
   const [file, setFile] = useState<File | null>(null);
   const [isDragging, setIsDragging] = useState<boolean>(false);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
@@ -26,7 +28,7 @@ export default function OnRamp() {
   const PINATA_CONFIGS = JSON.stringify({
     cidVersion: 1,
   });
-  const PINATA_CLOUD_ROOT = "https://gateway.pinata.cloud/ipfs/";
+  const PINATA_CLOUD_ROOT = 'https://gateway.pinata.cloud/ipfs/';
 
   const { data: hash, isPending, writeContract } = useWriteContract();
   const { isLoading: isConfirming, isSuccess: isConfirmed } = useWaitForTransactionReceipt({
@@ -115,27 +117,27 @@ export default function OnRamp() {
   };
 
   const handleUpload = async () => {
-    setLoading(true)
+    setLoading(true);
     if (file) {
       //Upload data to IPFS buffer using pinata
       const data = new FormData();
-      data.append("file", file);
-      data.append("pinataOptions", PINATA_CONFIGS);
-      console.log("Uploading")
+      data.append('file', file);
+      data.append('pinataOptions', PINATA_CONFIGS);
+      console.log('Uploading');
       const response = await uploadToIPFS(data);
       const fileIPFSHash = response?.ipfsHash;
       const ipfsURL = `${PINATA_CLOUD_ROOT}${fileIPFSHash}`;
 
       //Preparing CID and piece info
       const cid = await generateCID(file);
-      console.log("cid is ", cid.toString());
+      console.log('cid is ', cid.toString());
       const piece = await generatePiece(file);
       const pieceCid = piece.link.toString();
-      console.log("piece is ", piece.link.bytes);
-      console.log("piece CID is ", pieceCid);
+      console.log('piece is ', piece.link.bytes);
+      console.log('piece CID is ', pieceCid);
 
       const pieceCidBytes = ethers.hexlify(piece.link.bytes);
-      console.log("piece CID in bytes:", pieceCidBytes);
+      console.log('piece CID in bytes:', pieceCidBytes);
 
       const pieceSize = piece.padding;
 
@@ -148,25 +150,23 @@ export default function OnRamp() {
         amount: BigInt(0),
         token: WETH_ADDRESS as `0x${string}`,
       };
-      console.log("offer is ", offer);
+      console.log('offer is ', offer);
 
       try {
         writeContract({
           address: ONRAMP_CONTRACT_ADDRESS,
           abi: ONRAMP_CONTRACT_ABI,
-          functionName: "offerData",
+          functionName: 'offerData',
           args: [offer],
         });
-        setLoading(false)
+        setLoading(false);
       } catch (error) {
-        console.error("Error sending transaction:", error);
-        setLoading(false)
+        console.error('Error sending transaction:', error);
+        setLoading(false);
       }
-
     } else {
-      setError("No file is uploaded.");
+      setError('No file is uploaded.');
     }
-
   };
 
   const formatFileSize = (bytes: number): string => {
@@ -203,7 +203,6 @@ export default function OnRamp() {
 
       <div className="pt-16 bg-blue-600 h-screen">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-
           {/* Stats Section */}
           <div className="mt-6 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
             <div className="bg-white overflow-hidden shadow rounded-lg">
@@ -285,54 +284,67 @@ export default function OnRamp() {
                 {loading || isPending || isConfirming || isConfirmed ? (
                   <>
                     <div className="flex flex-row gap-2 justify-center items-center">
-                      {loading && <>
-                        <div className="w-4 h-4 rounded-full bg-blue-700 animate-bounce [animation-delay:.7s]"></div>
-                        <div className="w-4 h-4 rounded-full bg-blue-700 animate-bounce [animation-delay:.3s]"></div>
-                        <div className="w-4 h-4 rounded-full bg-blue-700 animate-bounce [animation-delay:.7s]"></div>
-                      </>}
-                      {isPending && <p className="items-left text-sm text-blue-800">Transaction pending...</p>}
-                      {isConfirming && <p className="items-left text-sm text-blue-800">Confirming transaction...</p>}
+                      {loading && (
+                        <>
+                          <div className="w-4 h-4 rounded-full bg-blue-700 animate-bounce [animation-delay:.7s]"></div>
+                          <div className="w-4 h-4 rounded-full bg-blue-700 animate-bounce [animation-delay:.3s]"></div>
+                          <div className="w-4 h-4 rounded-full bg-blue-700 animate-bounce [animation-delay:.7s]"></div>
+                        </>
+                      )}
+                      {isPending && (
+                        <p className="items-left text-sm text-blue-800">Transaction pending...</p>
+                      )}
+                      {isConfirming && (
+                        <p className="items-left text-sm text-blue-800">
+                          Confirming transaction...
+                        </p>
+                      )}
                       {/* {isConfirmed && hash && <p className="items-left text-sm text-blue-800">Transaction hash: {hash}</p>} */}
-                      {isConfirmed && hash && <div className="flex justify-center items-center flex-col">
-                        <img className="w-64 mb-16" src="https://cdn.vectorstock.com/i/500p/15/05/green-tick-checkmark-icon-vector-22691505.jpg" />
-                        <div className="flex flex-col gap-2 w-full text-[10px] sm:text-xs z-50">
-                          <div
-                            className="succsess-alert cursor-default flex items-center justify-between w-full h-12 sm:h-14 rounded-lg bg-[#232531] px-[10px]"
-                          >
-                            <div className="flex gap-2">
-                              <div className="text-[#2b9875] bg-white/5 backdrop-blur-xl p-1 rounded-lg">
-                                <svg
-                                  xmlns="http://www.w3.org/2000/svg"
-                                  fill="none"
-                                  viewBox="0 0 24 24"
-                                  stroke-width="1.5"
-                                  stroke="currentColor"
-                                  className="w-6 h-6"
-                                >
-                                  <path
-                                    stroke-linecap="round"
-                                    stroke-linejoin="round"
-                                    d="m4.5 12.75 6 6 9-13.5"
-                                  ></path>
-                                </svg>
-                              </div>
-                              <div>
-                                <p className="text-white">Transaction hash</p>
-                                <p className="text-gray-500">{hash}</p>
+                      {isConfirmed && hash && (
+                        <div className="flex justify-center items-center flex-col">
+                          <img
+                            className="w-64 mb-16"
+                            src="https://cdn.vectorstock.com/i/500p/15/05/green-tick-checkmark-icon-vector-22691505.jpg"
+                          />
+                          <div className="flex flex-col gap-2 w-full text-[10px] sm:text-xs z-50">
+                            <div className="succsess-alert cursor-default flex items-center justify-between w-full h-12 sm:h-14 rounded-lg bg-[#232531] px-[10px]">
+                              <div className="flex gap-2">
+                                <div className="text-[#2b9875] bg-white/5 backdrop-blur-xl p-1 rounded-lg">
+                                  <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke-width="1.5"
+                                    stroke="currentColor"
+                                    className="w-6 h-6"
+                                  >
+                                    <path
+                                      stroke-linecap="round"
+                                      stroke-linejoin="round"
+                                      d="m4.5 12.75 6 6 9-13.5"
+                                    ></path>
+                                  </svg>
+                                </div>
+                                <div>
+                                  <p className="text-white">Transaction hash</p>
+                                  <p className="text-gray-500">{hash}</p>
+                                </div>
                               </div>
                             </div>
                           </div>
                         </div>
-
-                      </div>}
+                      )}
                     </div>
                   </>
                 ) : (
                   <>
                     {!file ? (
                       <div
-                        className={`flex justify-center border-2 border-dashed rounded-xl h-96 transition-all ${isDragging ? 'border-blue-500 bg-blue-50' : 'border-gray-200 hover:border-blue-400'
-                          }`}
+                        className={`flex justify-center border-2 border-dashed rounded-xl h-96 transition-all ${
+                          isDragging
+                            ? 'border-blue-500 bg-blue-50'
+                            : 'border-gray-200 hover:border-blue-400'
+                        }`}
                         onDragEnter={handleDragEnter}
                         onDragLeave={handleDragLeave}
                         onDragOver={handleDragOver}
@@ -345,11 +357,10 @@ export default function OnRamp() {
                           </div>
                           <div className="text-center">
                             <p className="text-sm font-medium text-gray-700">
-                              <span className="text-blue-500">Click to upload</span> or drag and drop
+                              <span className="text-blue-500">Click to upload</span> or drag and
+                              drop
                             </p>
-                            <p className="text-xs text-gray-500 mt-1">
-                              Supports all file types
-                            </p>
+                            <p className="text-xs text-gray-500 mt-1">Supports all file types</p>
                           </div>
                         </div>
                         <input
@@ -362,17 +373,13 @@ export default function OnRamp() {
                     ) : (
                       <div className="space-y-4">
                         <div className="flex items-start gap-4 p-4 rounded-lg bg-gray-50">
-                          <div className="flex-shrink-0">
-                            {getFileIcon()}
-                          </div>
+                          <div className="flex-shrink-0">{getFileIcon()}</div>
                           <div className="flex-1 min-w-0">
-                            <h3 className="font-medium text-gray-900 truncate">
-                              {file.name}
-                            </h3>
+                            <h3 className="font-medium text-gray-900 truncate">{file.name}</h3>
                             <div className="mt-1 flex items-center gap-2 text-sm text-gray-500">
                               <span>{formatFileSize(file.size)}</span>
                               <span>•</span>
-                              <span>{file.type || "Unknown type"}</span>
+                              <span>{file.type || 'Unknown type'}</span>
                             </div>
                           </div>
                           <div>
@@ -460,14 +467,26 @@ export default function OnRamp() {
                         </div>
                         <div className="ml-3 flex flex-col flex-grow">
                           <span className="text-sm font-medium text-gray-900">
-                            {['project_report.pdf', 'image_assets.zip', 'presentation.pptx', 'contract.docx', 'financial_data.xlsx'][index]}
+                            {
+                              [
+                                'project_report.pdf',
+                                'image_assets.zip',
+                                'presentation.pptx',
+                                'contract.docx',
+                                'financial_data.xlsx',
+                              ][index]
+                            }
                           </span>
                           <span className="text-sm text-gray-500">
-                            {['2.5 MB', '8.2 MB', '4.7 MB', '1.2 MB', '3.8 MB'][index]} • Uploaded {['2 hours', '1 day', '3 days', '5 days', '1 week'][index]} ago
+                            {['2.5 MB', '8.2 MB', '4.7 MB', '1.2 MB', '3.8 MB'][index]} • Uploaded{' '}
+                            {['2 hours', '1 day', '3 days', '5 days', '1 week'][index]} ago
                           </span>
                         </div>
                         <div className="ml-4 flex-shrink-0 flex items-center space-x-2">
-                          <button type="button" className="text-sm font-medium text-gray-500 hover:text-gray-700">
+                          <button
+                            type="button"
+                            className="text-sm font-medium text-gray-500 hover:text-gray-700"
+                          >
                             Action Button
                           </button>
                         </div>
@@ -476,7 +495,10 @@ export default function OnRamp() {
                   </ul>
 
                   <div className="mt-4 text-center">
-                    <a href="#" className="text-sm font-medium text-indigo-600 hover:text-indigo-500">
+                    <a
+                      href="#"
+                      className="text-sm font-medium text-indigo-600 hover:text-indigo-500"
+                    >
                       View all files →
                     </a>
                   </div>
@@ -486,8 +508,6 @@ export default function OnRamp() {
           </div>
         </div>
       </div>
-
     </>
-  )
-
+  );
 }

--- a/app/onRamp/pinata.tsx
+++ b/app/onRamp/pinata.tsx
@@ -1,4 +1,4 @@
-"use server";
+'use server';
 
 export type PinataResponse = {
   ipfsHash: string;
@@ -10,16 +10,16 @@ export type PinataResponse = {
 export async function uploadToIPFS(data: FormData): Promise<PinataResponse> {
   try {
     const apiKey = process.env.NEXT_PUBLIC_PINATA_API_KEY;
-    console.log("PINATA API KEY:", apiKey)
-    const res = await fetch("https://api.pinata.cloud/pinning/pinFileToIPFS", {
-      method: "POST",
+    console.log('PINATA API KEY:', apiKey);
+    const res = await fetch('https://api.pinata.cloud/pinning/pinFileToIPFS', {
+      method: 'POST',
       headers: {
         Authorization: `Bearer ${apiKey}`,
       },
       body: data,
     });
 
-    console.log(res)
+    console.log(res);
 
     if (!res.ok) {
       throw new Error(`Failed to upload to IPFS: ${res.statusText}`);
@@ -34,7 +34,7 @@ export async function uploadToIPFS(data: FormData): Promise<PinataResponse> {
 
     return { ipfsHash, pinSize, timeStamp, isDuplicate };
   } catch (error) {
-    console.error("Error uploading to IPFS:", error);
+    console.error('Error uploading to IPFS:', error);
     throw error;
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,22 +1,21 @@
-import Header from "../components/header";
-import Footer from "../components/footer";
-import { WalletConnect } from "@/components/walletConnect";
-export default function Home() {
+import { WalletConnect } from '@/components/walletConnect';
 
+import Footer from '../components/footer';
+import Header from '../components/header';
+
+export default function Home() {
   return (
     <div className="w-full min-h-screen bg-blue-600">
       <Header />
-      <div >
+      <div>
         <div
           className="relative w-full pt-48 pb-40 m-auto flex justify-center text-center flex-col items-center z-1 text-white"
-          style={{ maxWidth: "1200px" }}
+          style={{ maxWidth: '1200px' }}
         >
           <h1 className="inline-block max-w-2xl lg:max-w-4xl  w-auto relative text-5xl md:text-6xl lg:text-7xl tracking-tighter mb-10 font-bold">
-            Cross-Chain Data Storage on Filecoin{" "}
+            Cross-Chain Data Storage on Filecoin{' '}
           </h1>
-          <p className="text-xl mb-5">
-            Effortlessly bridge your data to Filecoin from Avalanche
-          </p>
+          <p className="text-xl mb-5">Effortlessly bridge your data to Filecoin from Avalanche</p>
           <WalletConnect />
         </div>
       </div>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,37 +1,26 @@
 'use client';
 
+import { RainbowKitProvider, getDefaultConfig } from '@rainbow-me/rainbowkit';
 import '@rainbow-me/rainbowkit/styles.css';
-import {
-    getDefaultConfig,
-    RainbowKitProvider,
-} from '@rainbow-me/rainbowkit';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { WagmiProvider } from 'wagmi';
-import {
-    avalancheFuji,
-    filecoinCalibration
-} from 'wagmi/chains';
-import {
-    QueryClientProvider,
-    QueryClient,
-} from "@tanstack/react-query";
+import { avalancheFuji, filecoinCalibration } from 'wagmi/chains';
 
 const queryClient = new QueryClient();
 
 const config = getDefaultConfig({
-    appName: 'OnRamp',
-    projectId: 'WALLETCONNECT_PROJECT_ID',
-    chains: [avalancheFuji, filecoinCalibration],
-    ssr: true, // If your dApp uses server side rendering (SSR)
+  appName: 'OnRamp',
+  projectId: 'WALLETCONNECT_PROJECT_ID',
+  chains: [avalancheFuji, filecoinCalibration],
+  ssr: true, // If your dApp uses server side rendering (SSR)
 });
 
 export default function ContextProvider({ children }: { children: React.ReactNode }) {
-    return (
-        <WagmiProvider config={config}>
-            <QueryClientProvider client={queryClient}>
-                <RainbowKitProvider>
-                    {children}
-                </RainbowKitProvider>
-            </QueryClientProvider>
-        </WagmiProvider >
-    );
+  return (
+    <WagmiProvider config={config}>
+      <QueryClientProvider client={queryClient}>
+        <RainbowKitProvider>{children}</RainbowKitProvider>
+      </QueryClientProvider>
+    </WagmiProvider>
+  );
 }

--- a/components/contractDetails.tsx
+++ b/components/contractDetails.tsx
@@ -1,437 +1,437 @@
-export const ONRAMP_CONTRACT_ADDRESS = "0xeE857540dddB6E6EA10a5c84f57562F11D5Fb47D"
+export const ONRAMP_CONTRACT_ADDRESS = '0xeE857540dddB6E6EA10a5c84f57562F11D5Fb47D';
 
 export const ONRAMP_CONTRACT_ABI = [
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint64",
-          "name": "aggId",
-          "type": "uint64"
-        },
-        {
-          "indexed": false,
-          "internalType": "bytes",
-          "name": "commP",
-          "type": "bytes"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint64[]",
-          "name": "offerIDs",
-          "type": "uint64[]"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "payoutAddr",
-          "type": "address"
-        }
-      ],
-      "name": "AggregatonCommitted",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "components": [
-            {
-              "internalType": "bytes",
-              "name": "commP",
-              "type": "bytes"
-            },
-            {
-              "internalType": "uint64",
-              "name": "size",
-              "type": "uint64"
-            },
-            {
-              "internalType": "string",
-              "name": "location",
-              "type": "string"
-            },
-            {
-              "internalType": "uint256",
-              "name": "amount",
-              "type": "uint256"
-            },
-            {
-              "internalType": "contract IERC20",
-              "name": "token",
-              "type": "address"
-            }
-          ],
-          "indexed": false,
-          "internalType": "struct OnRampContract.Offer",
-          "name": "offer",
-          "type": "tuple"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint64",
-          "name": "id",
-          "type": "uint64"
-        }
-      ],
-      "name": "DataReady",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "bytes",
-          "name": "commP",
-          "type": "bytes"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint64",
-          "name": "dealID",
-          "type": "uint64"
-        }
-      ],
-      "name": "ProveDataStored",
-      "type": "event"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint64",
-          "name": "",
-          "type": "uint64"
-        }
-      ],
-      "name": "aggregationPayout",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint64",
-          "name": "",
-          "type": "uint64"
-        },
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "name": "aggregations",
-      "outputs": [
-        {
-          "internalType": "uint64",
-          "name": "",
-          "type": "uint64"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes",
-          "name": "",
-          "type": "bytes"
-        }
-      ],
-      "name": "commPToAggregateID",
-      "outputs": [
-        {
-          "internalType": "uint64",
-          "name": "",
-          "type": "uint64"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "bytes",
-          "name": "commP",
-          "type": "bytes"
-        },
-        {
-          "internalType": "uint64[]",
-          "name": "claimedIDs",
-          "type": "uint64[]"
-        },
-        {
-          "components": [
-            {
-              "internalType": "uint64",
-              "name": "index",
-              "type": "uint64"
-            },
-            {
-              "internalType": "bytes32[]",
-              "name": "path",
-              "type": "bytes32[]"
-            }
-          ],
-          "internalType": "struct PODSIVerifier.ProofData[]",
-          "name": "inclusionProofs",
-          "type": "tuple[]"
-        },
-        {
-          "internalType": "address",
-          "name": "payoutAddr",
-          "type": "address"
-        }
-      ],
-      "name": "commitAggregate",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "dataProofOracle",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "components": [
-            {
-              "internalType": "bytes",
-              "name": "commP",
-              "type": "bytes"
-            },
-            {
-              "internalType": "uint64",
-              "name": "size",
-              "type": "uint64"
-            },
-            {
-              "internalType": "string",
-              "name": "location",
-              "type": "string"
-            },
-            {
-              "internalType": "uint256",
-              "name": "amount",
-              "type": "uint256"
-            },
-            {
-              "internalType": "contract IERC20",
-              "name": "token",
-              "type": "address"
-            }
-          ],
-          "internalType": "struct OnRampContract.Offer",
-          "name": "offer",
-          "type": "tuple"
-        }
-      ],
-      "name": "offerData",
-      "outputs": [
-        {
-          "internalType": "uint64",
-          "name": "",
-          "type": "uint64"
-        }
-      ],
-      "stateMutability": "payable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint64",
-          "name": "",
-          "type": "uint64"
-        }
-      ],
-      "name": "offers",
-      "outputs": [
-        {
-          "internalType": "bytes",
-          "name": "commP",
-          "type": "bytes"
-        },
-        {
-          "internalType": "uint64",
-          "name": "size",
-          "type": "uint64"
-        },
-        {
-          "internalType": "string",
-          "name": "location",
-          "type": "string"
-        },
-        {
-          "internalType": "uint256",
-          "name": "amount",
-          "type": "uint256"
-        },
-        {
-          "internalType": "contract IERC20",
-          "name": "token",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "components": [
-            {
-              "internalType": "bytes",
-              "name": "commP",
-              "type": "bytes"
-            },
-            {
-              "internalType": "int64",
-              "name": "duration",
-              "type": "int64"
-            },
-            {
-              "internalType": "uint64",
-              "name": "dealID",
-              "type": "uint64"
-            },
-            {
-              "internalType": "uint256",
-              "name": "status",
-              "type": "uint256"
-            }
-          ],
-          "internalType": "struct DataAttestation",
-          "name": "attestation",
-          "type": "tuple"
-        }
-      ],
-      "name": "proveDataStored",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint64",
-          "name": "",
-          "type": "uint64"
-        }
-      ],
-      "name": "provenAggregations",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "oracle_",
-          "type": "address"
-        }
-      ],
-      "name": "setOracle",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "components": [
-            {
-              "internalType": "uint64",
-              "name": "index",
-              "type": "uint64"
-            },
-            {
-              "internalType": "bytes32[]",
-              "name": "path",
-              "type": "bytes32[]"
-            }
-          ],
-          "internalType": "struct PODSIVerifier.ProofData",
-          "name": "proof",
-          "type": "tuple"
-        },
-        {
-          "internalType": "bytes32",
-          "name": "root",
-          "type": "bytes32"
-        },
-        {
-          "internalType": "bytes32",
-          "name": "leaf",
-          "type": "bytes32"
-        }
-      ],
-      "name": "verify",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "pure",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint64",
-          "name": "aggID",
-          "type": "uint64"
-        },
-        {
-          "internalType": "uint256",
-          "name": "idx",
-          "type": "uint256"
-        },
-        {
-          "internalType": "uint64",
-          "name": "offerID",
-          "type": "uint64"
-        }
-      ],
-      "name": "verifyDataStored",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    }
-  ]
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint64',
+        name: 'aggId',
+        type: 'uint64',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes',
+        name: 'commP',
+        type: 'bytes',
+      },
+      {
+        indexed: false,
+        internalType: 'uint64[]',
+        name: 'offerIDs',
+        type: 'uint64[]',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'payoutAddr',
+        type: 'address',
+      },
+    ],
+    name: 'AggregatonCommitted',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes',
+            name: 'commP',
+            type: 'bytes',
+          },
+          {
+            internalType: 'uint64',
+            name: 'size',
+            type: 'uint64',
+          },
+          {
+            internalType: 'string',
+            name: 'location',
+            type: 'string',
+          },
+          {
+            internalType: 'uint256',
+            name: 'amount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'contract IERC20',
+            name: 'token',
+            type: 'address',
+          },
+        ],
+        indexed: false,
+        internalType: 'struct OnRampContract.Offer',
+        name: 'offer',
+        type: 'tuple',
+      },
+      {
+        indexed: false,
+        internalType: 'uint64',
+        name: 'id',
+        type: 'uint64',
+      },
+    ],
+    name: 'DataReady',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'bytes',
+        name: 'commP',
+        type: 'bytes',
+      },
+      {
+        indexed: false,
+        internalType: 'uint64',
+        name: 'dealID',
+        type: 'uint64',
+      },
+    ],
+    name: 'ProveDataStored',
+    type: 'event',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    name: 'aggregationPayout',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    name: 'aggregations',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes',
+        name: '',
+        type: 'bytes',
+      },
+    ],
+    name: 'commPToAggregateID',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes',
+        name: 'commP',
+        type: 'bytes',
+      },
+      {
+        internalType: 'uint64[]',
+        name: 'claimedIDs',
+        type: 'uint64[]',
+      },
+      {
+        components: [
+          {
+            internalType: 'uint64',
+            name: 'index',
+            type: 'uint64',
+          },
+          {
+            internalType: 'bytes32[]',
+            name: 'path',
+            type: 'bytes32[]',
+          },
+        ],
+        internalType: 'struct PODSIVerifier.ProofData[]',
+        name: 'inclusionProofs',
+        type: 'tuple[]',
+      },
+      {
+        internalType: 'address',
+        name: 'payoutAddr',
+        type: 'address',
+      },
+    ],
+    name: 'commitAggregate',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'dataProofOracle',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes',
+            name: 'commP',
+            type: 'bytes',
+          },
+          {
+            internalType: 'uint64',
+            name: 'size',
+            type: 'uint64',
+          },
+          {
+            internalType: 'string',
+            name: 'location',
+            type: 'string',
+          },
+          {
+            internalType: 'uint256',
+            name: 'amount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'contract IERC20',
+            name: 'token',
+            type: 'address',
+          },
+        ],
+        internalType: 'struct OnRampContract.Offer',
+        name: 'offer',
+        type: 'tuple',
+      },
+    ],
+    name: 'offerData',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    name: 'offers',
+    outputs: [
+      {
+        internalType: 'bytes',
+        name: 'commP',
+        type: 'bytes',
+      },
+      {
+        internalType: 'uint64',
+        name: 'size',
+        type: 'uint64',
+      },
+      {
+        internalType: 'string',
+        name: 'location',
+        type: 'string',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'contract IERC20',
+        name: 'token',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes',
+            name: 'commP',
+            type: 'bytes',
+          },
+          {
+            internalType: 'int64',
+            name: 'duration',
+            type: 'int64',
+          },
+          {
+            internalType: 'uint64',
+            name: 'dealID',
+            type: 'uint64',
+          },
+          {
+            internalType: 'uint256',
+            name: 'status',
+            type: 'uint256',
+          },
+        ],
+        internalType: 'struct DataAttestation',
+        name: 'attestation',
+        type: 'tuple',
+      },
+    ],
+    name: 'proveDataStored',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    name: 'provenAggregations',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'oracle_',
+        type: 'address',
+      },
+    ],
+    name: 'setOracle',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'uint64',
+            name: 'index',
+            type: 'uint64',
+          },
+          {
+            internalType: 'bytes32[]',
+            name: 'path',
+            type: 'bytes32[]',
+          },
+        ],
+        internalType: 'struct PODSIVerifier.ProofData',
+        name: 'proof',
+        type: 'tuple',
+      },
+      {
+        internalType: 'bytes32',
+        name: 'root',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'bytes32',
+        name: 'leaf',
+        type: 'bytes32',
+      },
+    ],
+    name: 'verify',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'pure',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint64',
+        name: 'aggID',
+        type: 'uint64',
+      },
+      {
+        internalType: 'uint256',
+        name: 'idx',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint64',
+        name: 'offerID',
+        type: 'uint64',
+      },
+    ],
+    name: 'verifyDataStored',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,4 +1,4 @@
-import Image from "next/image";
+import Image from 'next/image';
 
 export default function Footer() {
   return (
@@ -8,41 +8,20 @@ export default function Footer() {
           className="text-black items-center inline-flex bg-white border-2 border-black duration-200 ease-in-out focus:outline-none hover:bg-black hover:shadow-none hover:text-white justify-center rounded-full shadow-[5px_5px_black] text-center transform transition w-full px-2 py-2"
           href="https://x.com/FILBuilders"
         >
-          <Image
-            src="/assets/logos/x-logo.png"
-            width={30}
-            height={30}
-            alt="X Logo"
-          />
+          <Image src="/assets/logos/x-logo.png" width={30} height={30} alt="X Logo" />
         </a>
 
         <a
           className="text-black items-center inline-flex bg-white border-2 border-black duration-200 ease-in-out focus:outline-none hover:bg-black hover:shadow-none hover:text-white justify-center rounded-full shadow-[5px_5px_black] text-center transform transition w-full px-2 py-2"
           href="https://discord.com/invite/filecoin"
         >
-          <Image
-            src="/assets/logos/discord-logo.png"
-            width={30}
-            height={30}
-            alt="Discord Logo"
-          />
+          <Image src="/assets/logos/discord-logo.png" width={30} height={30} alt="Discord Logo" />
         </a>
       </div>
       <div className="flex flex-row gap-2 justify-center items-center mb-2">
-        <p className="inline-block text-white">
-
-          Made with
-        </p>
-        <Image
-          src="/assets/icons/heart.png"
-          width={30}
-          height={30}
-          alt="Heart Icon"
-        />
-        <p className="inline-block text-white">
-
-          by Team FIL-B
-        </p>
+        <p className="inline-block text-white">Made with</p>
+        <Image src="/assets/icons/heart.png" width={30} height={30} alt="Heart Icon" />
+        <p className="inline-block text-white">by Team FIL-B</p>
       </div>
     </div>
   );

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,11 +1,12 @@
-"use client"
-import Image from "next/image";
-import Link from 'next/link'
-import { WalletConnect } from "./walletConnect";
-import { NavbarWalletComponent } from "./navbarWalletComponent";
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+
+import { NavbarWalletComponent } from './navbarWalletComponent';
+import { WalletConnect } from './walletConnect';
 
 const Header = () => {
-
   return (
     <div className="fixed top-0 w-full bg-blue-600 h-20 flex items-center z-10">
       <div className="relative left-4">
@@ -17,9 +18,7 @@ const Header = () => {
             height={250}
             alt="FIL-B Logo"
           />
-          <div
-            className="lg:hidden text-black items-center inline-flex bg-white border-2 border-black duration-200 ease-in-out focus:outline-none hover:bg-black hover:shadow-none hover:text-white justify-center rounded-full shadow-[5px_5px_black] text-center transform transition w-full px-2 py-2"
-          >
+          <div className="lg:hidden text-black items-center inline-flex bg-white border-2 border-black duration-200 ease-in-out focus:outline-none hover:bg-black hover:shadow-none hover:text-white justify-center rounded-full shadow-[5px_5px_black] text-center transform transition w-full px-2 py-2">
             <Image
               className="cursor-pointer "
               src="/assets/logos/fil-b-mini-logo.png"
@@ -35,7 +34,7 @@ const Header = () => {
           <NavbarWalletComponent />
         </div>
       </div>
-    </div >
+    </div>
   );
 };
 

--- a/components/loader.tsx
+++ b/components/loader.tsx
@@ -1,9 +1,9 @@
 export default function Footer() {
-    return (
-        <div className="flex flex-row gap-2">
-            <div className="w-4 h-4 rounded-full bg-yellow-300 animate-bounce [animation-delay:.7s]"></div>
-            <div className="w-4 h-4 rounded-full bg-yellow-300 animate-bounce [animation-delay:.3s]"></div>
-            <div className="w-4 h-4 rounded-full bg-yellow-300 animate-bounce [animation-delay:.7s]"></div>
-        </div>
-    );
+  return (
+    <div className="flex flex-row gap-2">
+      <div className="w-4 h-4 rounded-full bg-yellow-300 animate-bounce [animation-delay:.7s]"></div>
+      <div className="w-4 h-4 rounded-full bg-yellow-300 animate-bounce [animation-delay:.3s]"></div>
+      <div className="w-4 h-4 rounded-full bg-yellow-300 animate-bounce [animation-delay:.7s]"></div>
+    </div>
+  );
 }

--- a/components/navbarWalletComponent.tsx
+++ b/components/navbarWalletComponent.tsx
@@ -1,105 +1,101 @@
-"use client"
-import { ConnectButton } from '@rainbow-me/rainbowkit';
-import Link from 'next/link';
-import { useAccount, useBalance } from 'wagmi';
+'use client';
+
 import { useEffect } from 'react';
 
+import Link from 'next/link';
+
+import { ConnectButton } from '@rainbow-me/rainbowkit';
+import { useAccount, useBalance } from 'wagmi';
+
 export const NavbarWalletComponent = () => {
+  const { address } = useAccount();
+  const { data: balance } = useBalance({ address });
 
-    const { address } = useAccount();
-    const { data: balance } = useBalance({ address });
-
-    return (
-        <ConnectButton.Custom>
-            {({
-                account,
-                chain,
-                openChainModal,
-                openConnectModal,
-                openAccountModal,
-                authenticationStatus,
-                mounted,
-            }) => {
-                const ready = mounted && authenticationStatus !== 'loading';
-                const connected =
-                    ready &&
-                    account &&
-                    chain &&
-                    (!authenticationStatus ||
-                        authenticationStatus === 'authenticated');
-                return (
-                    <div
-                        {...(!ready && {
-                            'aria-hidden': true,
-                            'style': {
-                                opacity: 0,
-                                pointerEvents: 'none',
-                                userSelect: 'none',
-                            },
-                        })}
+  return (
+    <ConnectButton.Custom>
+      {({
+        account,
+        chain,
+        openChainModal,
+        openConnectModal,
+        openAccountModal,
+        authenticationStatus,
+        mounted,
+      }) => {
+        const ready = mounted && authenticationStatus !== 'loading';
+        const connected =
+          ready &&
+          account &&
+          chain &&
+          (!authenticationStatus || authenticationStatus === 'authenticated');
+        return (
+          <div
+            {...(!ready && {
+              'aria-hidden': true,
+              style: {
+                opacity: 0,
+                pointerEvents: 'none',
+                userSelect: 'none',
+              },
+            })}
+          >
+            {(() => {
+              if (connected) {
+                if (chain.unsupported) {
+                  return (
+                    <button
+                      onClick={openChainModal}
+                      className="text-black items-center inline-flex bg-white border-2 border-black duration-200 ease-in-out focus:outline-none hover:bg-black hover:shadow-none hover:text-white justify-center rounded-[20px] shadow-[5px_5px_black] text-center transform transition w-full lg:px-8 lg:py-2 lg:text-xl px-8 py-2"
                     >
-                        {(() => {
-                            if (connected) {
-
-                                if (chain.unsupported) {
-                                    return (
-                                        <button onClick={openChainModal} className="text-black items-center inline-flex bg-white border-2 border-black duration-200 ease-in-out focus:outline-none hover:bg-black hover:shadow-none hover:text-white justify-center rounded-[20px] shadow-[5px_5px_black] text-center transform transition w-full lg:px-8 lg:py-2 lg:text-xl px-8 py-2">
-                                            Wrong network
-                                        </button>
-                                    );
-                                }
-                                return (
-                                    <div style={{ display: 'flex', gap: 12 }}>
-                                        <div className="text-black items-center inline-flex bg-white border-2 border-black duration-200 ease-in-out focus:outline-none hover:bg-black hover:shadow-none hover:text-white justify-center rounded-[20px] shadow-[5px_5px_black] text-center transform transition w-full lg:px-8 lg:py-2 lg:text-xl px-8 py-2">
-
-                                            <div style={{ display: 'flex', gap: 12 }}>
-                                                <button
-                                                    onClick={openChainModal}
-                                                    style={{ display: 'flex', alignItems: 'center' }}
-                                                    type="button"
-                                                >
-                                                    {chain.hasIcon && (
-                                                        <div
-                                                            style={{
-                                                                background: chain.iconBackground,
-                                                                width: 20,
-                                                                height: 20,
-                                                                borderRadius: 999,
-                                                                overflow: 'hidden',
-                                                                marginRight: 4,
-
-                                                            }}
-                                                        >
-                                                            {chain.iconUrl && (
-                                                                <img
-                                                                    alt={chain.name ?? 'Chain icon'}
-                                                                    src={chain.iconUrl}
-                                                                    style={{ width: 20, height: 20 }}
-                                                                />
-                                                            )}
-                                                        </div>
-                                                    )}
-                                                    {chain.name}
-                                                </button>
-                                                |
-                                                <button onClick={openAccountModal} type="button">
-                                                    {account.displayName}
-                                                    {account.displayBalance
-                                                        ? ` (${account.displayBalance})`
-                                                        : ''}
-                                                </button>
-                                            </div>
-                                        </div>
-
-                                    </div>
-                                );
-                            }
-                        })()}
+                      Wrong network
+                    </button>
+                  );
+                }
+                return (
+                  <div style={{ display: 'flex', gap: 12 }}>
+                    <div className="text-black items-center inline-flex bg-white border-2 border-black duration-200 ease-in-out focus:outline-none hover:bg-black hover:shadow-none hover:text-white justify-center rounded-[20px] shadow-[5px_5px_black] text-center transform transition w-full lg:px-8 lg:py-2 lg:text-xl px-8 py-2">
+                      <div style={{ display: 'flex', gap: 12 }}>
+                        <button
+                          onClick={openChainModal}
+                          style={{ display: 'flex', alignItems: 'center' }}
+                          type="button"
+                        >
+                          {chain.hasIcon && (
+                            <div
+                              style={{
+                                background: chain.iconBackground,
+                                width: 20,
+                                height: 20,
+                                borderRadius: 999,
+                                overflow: 'hidden',
+                                marginRight: 4,
+                              }}
+                            >
+                              {chain.iconUrl && (
+                                <img
+                                  alt={chain.name ?? 'Chain icon'}
+                                  src={chain.iconUrl}
+                                  style={{ width: 20, height: 20 }}
+                                />
+                              )}
+                            </div>
+                          )}
+                          {chain.name}
+                        </button>
+                        |
+                        <button onClick={openAccountModal} type="button">
+                          {account.displayName}
+                          {account.displayBalance ? ` (${account.displayBalance})` : ''}
+                        </button>
+                      </div>
                     </div>
-
-
+                  </div>
                 );
-            }}
-        </ConnectButton.Custom>
-    );
+              }
+            })()}
+          </div>
+        );
+      }}
+    </ConnectButton.Custom>
+  );
 };

--- a/components/walletConnect.tsx
+++ b/components/walletConnect.tsx
@@ -1,68 +1,63 @@
-"use client"
-import { ConnectButton } from '@rainbow-me/rainbowkit';
+'use client';
+
 import Link from 'next/link';
 
+import { ConnectButton } from '@rainbow-me/rainbowkit';
+
 export const WalletConnect = () => {
-
-    return (
-        <ConnectButton.Custom>
-            {({
-                account,
-                chain,
-                openChainModal,
-                openConnectModal,
-                authenticationStatus,
-                mounted,
-            }) => {
-                const ready = mounted && authenticationStatus !== 'loading';
-                const connected =
-                    ready &&
-                    account &&
-                    chain &&
-                    (!authenticationStatus ||
-                        authenticationStatus === 'authenticated');
+  return (
+    <ConnectButton.Custom>
+      {({ account, chain, openChainModal, openConnectModal, authenticationStatus, mounted }) => {
+        const ready = mounted && authenticationStatus !== 'loading';
+        const connected =
+          ready &&
+          account &&
+          chain &&
+          (!authenticationStatus || authenticationStatus === 'authenticated');
+        return (
+          <div
+            {...(!ready && {
+              'aria-hidden': true,
+              style: {
+                opacity: 0,
+                pointerEvents: 'none',
+                userSelect: 'none',
+              },
+            })}
+          >
+            {(() => {
+              if (!connected) {
                 return (
-                    <div
-                        {...(!ready && {
-                            'aria-hidden': true,
-                            'style': {
-                                opacity: 0,
-                                pointerEvents: 'none',
-                                userSelect: 'none',
-                            },
-                        })}
-                    >
-                        {(() => {
-                            if (!connected) {
-                                return (
-                                    <button onClick={openConnectModal} type="button">
-                                        <div className="text-black items-center inline-flex bg-white border-2 border-black duration-200 ease-in-out focus:outline-none hover:bg-black hover:shadow-none hover:text-white justify-center rounded-[20px] shadow-[5px_5px_black] text-center transform transition w-full lg:px-8 lg:py-2 lg:text-xl px-8 py-2">
-                                            Connect Wallet
-                                        </div>
-                                    </button>
-                                );
-                            }
-                            if (chain.unsupported) {
-                                return (
-                                    <button onClick={openChainModal} className="text-black items-center inline-flex bg-white border-2 border-black duration-200 ease-in-out focus:outline-none hover:bg-black hover:shadow-none hover:text-white justify-center rounded-[20px] shadow-[5px_5px_black] text-center transform transition w-full lg:px-8 lg:py-2 lg:text-xl px-8 py-2">
-                                        Wrong network
-                                    </button>
-                                );
-                            }
-                            return (
-                                <div style={{ display: 'flex', gap: 12 }}>
-
-                                    <Link href="/onRamp">
-                                        <div className="text-black items-center inline-flex bg-white border-2 border-black duration-200 ease-in-out focus:outline-none hover:bg-black hover:shadow-none hover:text-white justify-center rounded-[20px] shadow-[5px_5px_black] text-center transform transition w-full lg:px-8 lg:py-2 lg:text-xl px-8 py-2">
-                                            Launch dApp
-                                        </div>
-                                    </Link>
-                                </div>
-                            );
-                        })()}
+                  <button onClick={openConnectModal} type="button">
+                    <div className="text-black items-center inline-flex bg-white border-2 border-black duration-200 ease-in-out focus:outline-none hover:bg-black hover:shadow-none hover:text-white justify-center rounded-[20px] shadow-[5px_5px_black] text-center transform transition w-full lg:px-8 lg:py-2 lg:text-xl px-8 py-2">
+                      Connect Wallet
                     </div>
+                  </button>
                 );
-            }}
-        </ConnectButton.Custom>
-    );
+              }
+              if (chain.unsupported) {
+                return (
+                  <button
+                    onClick={openChainModal}
+                    className="text-black items-center inline-flex bg-white border-2 border-black duration-200 ease-in-out focus:outline-none hover:bg-black hover:shadow-none hover:text-white justify-center rounded-[20px] shadow-[5px_5px_black] text-center transform transition w-full lg:px-8 lg:py-2 lg:text-xl px-8 py-2"
+                  >
+                    Wrong network
+                  </button>
+                );
+              }
+              return (
+                <div style={{ display: 'flex', gap: 12 }}>
+                  <Link href="/onRamp">
+                    <div className="text-black items-center inline-flex bg-white border-2 border-black duration-200 ease-in-out focus:outline-none hover:bg-black hover:shadow-none hover:text-white justify-center rounded-[20px] shadow-[5px_5px_black] text-center transform transition w-full lg:px-8 lg:py-2 lg:text-xl px-8 py-2">
+                      Launch dApp
+                    </div>
+                  </Link>
+                </div>
+              );
+            })()}
+          </div>
+        );
+      }}
+    </ConnectButton.Custom>
+  );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,12 +25,15 @@
         "web3.storage": "^4.5.5"
       },
       "devDependencies": {
+        "@trivago/prettier-plugin-sort-imports": "^5.2.2",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "eslint": "^8",
         "eslint-config-next": "14.2.7",
         "postcss": "^8",
+        "prettier": "^3.5.3",
+        "prettier-plugin-tailwindcss": "^0.6.11",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
       }
@@ -70,6 +73,33 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/generator": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.10.tgz",
+      "integrity": "sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.26.10",
+        "@babel/types": "^7.26.10",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
@@ -78,12 +108,86 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/parser": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.10"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.26.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
       "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.10.tgz",
+      "integrity": "sha512-k8NuDrxr0WrPH5Aupqb2LCVURP/S0vBEn5mK6iH+GIYob66U5EtoZvcdudR2jQ4cmTwhEwW1DLB+Yyas9zjF6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.10",
+        "@babel/parser": "^7.26.10",
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.10",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1342,6 +1446,41 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-5.2.2.tgz",
+      "integrity": "sha512-fYDQA9e6yTNmA13TLVSA+WMQRc5Bn/c0EUBditUHNfMMxN7M82c38b1kEggVE3pLpZ0FwkwJkUEKMiOi52JXFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/generator": "^7.26.5",
+        "@babel/parser": "^7.26.7",
+        "@babel/traverse": "^7.26.7",
+        "@babel/types": "^7.26.7",
+        "javascript-natural-sort": "^0.7.1",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">18.12"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "3.x",
+        "prettier": "2.x - 3.x",
+        "prettier-plugin-svelte": "3.x",
+        "svelte": "4.x || 5.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/@types/debug": {
@@ -7013,6 +7152,13 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -7045,6 +7191,19 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -8561,6 +8720,101 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.11.tgz",
+      "integrity": "sha512-YxaYSIvZPAqhrrEpRtonnrXdghZg1irNg4qrjboCXrpybLWVs55cW2N3juhspVJiO0JBvYJT8SYsJpc8OQSnsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/process": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@rainbow-me/rainbowkit": "^2.2.3",
@@ -26,12 +28,15 @@
     "web3.storage": "^4.5.5"
   },
   "devDependencies": {
+    "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^8",
     "eslint-config-next": "14.2.7",
     "postcss": "^8",
+    "prettier": "^3.5.3",
+    "prettier-plugin-tailwindcss": "^0.6.11",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -18,11 +18,7 @@
 
 body {
   color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
+  background: linear-gradient(to bottom, transparent, rgb(var(--background-end-rgb)))
     rgb(var(--background-start-rgb));
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,23 +1,22 @@
-import type { Config } from "tailwindcss";
+import type { Config } from 'tailwindcss';
 
 const config: Config = {
   content: [
-    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    './pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     extend: {
       screens: {
-        'sm': '640px',    // Default Tailwind 'sm'
-        'md': '768px',    // Default Tailwind 'md'
-        'lg': '1024px',   // Default Tailwind 'lg'
+        sm: '640px', // Default Tailwind 'sm'
+        md: '768px', // Default Tailwind 'md'
+        lg: '1024px', // Default Tailwind 'lg'
       },
       backgroundImage: {
-        "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-        "gradient-conic":
-          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
-        "login-background": "url('/assets/images/loginBackground.png')"
+        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
+        'gradient-conic': 'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
+        'login-background': "url('/assets/images/loginBackground.png')",
       },
     },
   },

--- a/utils/dataPrep.tsx
+++ b/utils/dataPrep.tsx
@@ -1,50 +1,50 @@
-import { CID } from "multiformats/cid";
-import { base32 } from 'multiformats/bases/base32';
+import { Piece } from '@web3-storage/data-segment';
 import { importer } from 'ipfs-unixfs-importer';
-import { Piece } from "@web3-storage/data-segment";
+import { base32 } from 'multiformats/bases/base32';
+import { CID } from 'multiformats/cid';
 
 // Generate a CID using sha256
 export async function generateCID(file: File): Promise<CID> {
-    try {
-      const blockstore = {
-        store: new Map<string, Uint8Array>(),
-        async put(cid: CID, bytes: Uint8Array) {
-          this.store.set(cid.toString(), bytes);
-          return cid;
-        },
-        async get(cid: CID) {
-          return this.store.get(cid.toString());
-        },
-      };
-  
-      const options = {
-        maxChunkSize: 262144, // 256 KB chunk size
-        rawLeaves: true, // Use DAG-PB encoding (not raw leaves)
-      };
-  
-      const fileContents = await file.arrayBuffer();
-      const uint8Array = new Uint8Array(fileContents);
-  
-      const source = [{ content: uint8Array }]; // Use Uint8Array instead of ReadableStream
-  
-      for await (const file of importer(source, blockstore, options)) {
-        console.log("Generated CID:", file.cid.toString(base32));
-        return file.cid;
-      }
-  
-      throw new Error("No CID was generated for the file.");
-    } catch (error) {
-      if (error instanceof Error) {
-        console.error("Error replicating IPFS add:", error.message);
-      } else {
-        console.error("Unknown error replicating IPFS add");
-      }
-      throw error; // Re-throw the error to handle it in the calling function
-    }
-  }
+  try {
+    const blockstore = {
+      store: new Map<string, Uint8Array>(),
+      async put(cid: CID, bytes: Uint8Array) {
+        this.store.set(cid.toString(), bytes);
+        return cid;
+      },
+      async get(cid: CID) {
+        return this.store.get(cid.toString());
+      },
+    };
 
- export async function generatePiece(file: File) {
-    const bytes = new Uint8Array(await file.arrayBuffer());
-    const piece = Piece.fromPayload(bytes);
-    return piece;
+    const options = {
+      maxChunkSize: 262144, // 256 KB chunk size
+      rawLeaves: true, // Use DAG-PB encoding (not raw leaves)
+    };
+
+    const fileContents = await file.arrayBuffer();
+    const uint8Array = new Uint8Array(fileContents);
+
+    const source = [{ content: uint8Array }]; // Use Uint8Array instead of ReadableStream
+
+    for await (const file of importer(source, blockstore, options)) {
+      console.log('Generated CID:', file.cid.toString(base32));
+      return file.cid;
+    }
+
+    throw new Error('No CID was generated for the file.');
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error('Error replicating IPFS add:', error.message);
+    } else {
+      console.error('Unknown error replicating IPFS add');
+    }
+    throw error; // Re-throw the error to handle it in the calling function
   }
+}
+
+export async function generatePiece(file: File) {
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const piece = Piece.fromPayload(bytes);
+  return piece;
+}


### PR DESCRIPTION
## Changes
This PR adds Prettier configuration to standardize code formatting across the project.

### Added Files
- `.prettierrc` - Core Prettier configuration
- `.prettierignore` - Excludes specific files/directories from formatting
- `.vscode/settings.json` - VS Code integration settings

### Package Changes
Added dev dependencies:
- `prettier` (^3.5.3)
- `prettier-plugin-tailwindcss` (^0.6.11)
- `@trivago/prettier-plugin-sort-imports` (^5.2.2)

### Configuration Highlights
- Line width: 100 characters
- Single quotes for strings
- 2-space indentation
- Automatic import sorting and grouping
- Tailwind CSS class sorting
- ES5 trailing commas
- Consistent arrow function parentheses

### New npm Scripts
```bash
npm run format      # Format all files
npm run format:check # Check files without modifying
```

### VS Code Integration
Added workspace settings for:
- Format on save
- ESLint fix on save
- Prettier as default formatter

## How to Test
1. Install dependencies: `npm install`
2. Try formatting: `npm run format`
3. Check formatting: `npm run format:check`
4. Open any file in VS Code and save to verify auto-formatting

## Related Issues
Closes #1 